### PR TITLE
Add a test command to send DMs to members with a selected role

### DIFF
--- a/addCommands.js
+++ b/addCommands.js
@@ -32,6 +32,18 @@ const commands = [
         ],
     },
     {
+        name: "test_dm",
+        description: "Send test DMs from the bot to members with a selected role",
+        options: [
+            {
+                name: "role",
+                description: "Select a role.",
+                type: 8,
+                required: true,
+            },
+        ],
+    },
+    {
         name: "approve",
         description: "send your share.",
         options: [

--- a/index.js
+++ b/index.js
@@ -246,6 +246,24 @@ client.on("interactionCreate", async (interaction) => {
 			ephemeral: true,
 		});
 	}
+
+	if (interaction.commandName === "test_dm") {
+		const guild = await client.guilds.fetch(interaction.guildId);
+		await guild.members.fetch();
+		const role = guild.roles.cache.get(interaction.options.getRole("role").id);
+		for (const [key, user] of role.members) {
+			try {
+				await user.send('ボットからのDM送信のテストです。とくにアクションは必要ありません。');
+			} catch {
+				await interaction.editReply({
+					content: `DM送信中にエラーが発生しました。\nuser: ${user.nickname ?? user.displayName}`,
+					ephemeral: true,
+				});
+				return;
+			}
+		}
+	}
+
 	if (interaction.customId === "firstOption") {
 		let lock;
 		try {


### PR DESCRIPTION
## 問題

`/init` コマンド実行時のシェアのDM送信がatomic処理ではないため、途中で失敗するとその時に作られたシェアが一部の人にしか送られずどのシェアが最新のものか分かりにくくなるという問題がある

## 解決策

テストコマンドとしてロールを選ぶとテストDMがボットから送られるものを追加した。これによって `/init` コマンド実行前に作られたシェアがすべての必要なユーザに送られることを確認できる

## 注意

本番サーバへのテストコマンドの実行は未実施。ロジックは `/ping` コマンドに同様の処理を入れることで確認したが、本番サーバへの展開後、統合テストが必要。